### PR TITLE
Fix typos in basis module documentation

### DIFF
--- a/basis/IntProgScript.sml
+++ b/basis/IntProgScript.sml
@@ -1,6 +1,6 @@
 (*
   Module about the built-in integer type. Note that CakeML uses
-  arbitrary precision integers (the mathematical intergers).
+  arbitrary precision integers (the mathematical integers).
 *)
 Theory IntProg
 Ancestors

--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -1,5 +1,5 @@
 (*
-  Module about the built-in list tyoe.
+  Module about the built-in list type.
 *)
 Theory ListProg
 Ancestors

--- a/basis/ListProofScript.sml
+++ b/basis/ListProofScript.sml
@@ -1,5 +1,5 @@
 (*
-  Proofs about the module about the list tyoe.
+  Proofs about the module about the list type.
 *)
 Theory ListProof
 Ancestors

--- a/basis/OptionProgScript.sml
+++ b/basis/OptionProgScript.sml
@@ -1,5 +1,5 @@
 (*
-  Module about the option tyoe.
+  Module about the option type.
 *)
 Theory OptionProg
 Libs

--- a/basis/README.md
+++ b/basis/README.md
@@ -35,13 +35,13 @@ Proof of the hashtable module
 
 [IntProgScript.sml](IntProgScript.sml):
 Module about the built-in integer type. Note that CakeML uses
-arbitrary precision integers (the mathematical intergers).
+arbitrary precision integers (the mathematical integers).
 
 [ListProgScript.sml](ListProgScript.sml):
-Module about the built-in list tyoe.
+Module about the built-in list type.
 
 [ListProofScript.sml](ListProofScript.sml):
-Proofs about the module about the list tyoe.
+Proofs about the module about the list type.
 
 [MapProgScript.sml](MapProgScript.sml):
 This module contains CakeML code implementing a functional map type
@@ -56,7 +56,7 @@ HOL functions that aid converting to and from the byte arrays that
 CakeML foreign-function interface (FFI) uses.
 
 [OptionProgScript.sml](OptionProgScript.sml):
-Module about the option tyoe.
+Module about the option type.
 
 [PrettyPrinterProgScript.sml](PrettyPrinterProgScript.sml):
 Module providing pretty-printer implementation, and setup
@@ -77,7 +77,7 @@ This module contains CakeML code implementing a functional set type
 using a self-balancing binary tree.
 
 [StringProgScript.sml](StringProgScript.sml):
-Module about the built-in string tyoe.
+Module about the built-in string type.
 
 [TextIOProgScript.sml](TextIOProgScript.sml):
 Module for text-based I/O with the underlying file system.

--- a/basis/StringProgScript.sml
+++ b/basis/StringProgScript.sml
@@ -1,5 +1,5 @@
 (*
-  Module about the built-in string tyoe.
+  Module about the built-in string type.
 *)
 Theory StringProg
 Ancestors


### PR DESCRIPTION
## Summary
- correct several module header comments that misspelled "type"
- fix the README and integer module comment to spell "integers" correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca958e19d48326b53615ec39c2eb0f